### PR TITLE
fix small bug with melee reaction

### DIFF
--- a/src/Battlescape/MeleeAttackBState.cpp
+++ b/src/Battlescape/MeleeAttackBState.cpp
@@ -192,7 +192,10 @@ void MeleeAttackBState::think()
 			_parent->getMap()->invalidate();
 		}
 
-		_parent->getCurrentAction()->type = BA_NONE; // do this to restore cursor
+		if (_unit->getFaction() == _parent->getSave()->getSide()) // not a reaction attack
+		{
+			_parent->getCurrentAction()->type = BA_NONE; // do this to restore cursor
+		}
 
 		if (_parent->getSave()->getSide() == FACTION_PLAYER || _parent->getSave()->getDebugMode())
 		{


### PR DESCRIPTION
don't set the parent action type to BA_NONE when reacting, so as not
to mess with the action we're reacting TO.